### PR TITLE
Add blob selection

### DIFF
--- a/blob_race.p8
+++ b/blob_race.p8
@@ -12,6 +12,7 @@ log_msg = ""
 state = "start"
 selected_blob = 0
 arrow_phase = rnd(1)
+lock_timer = 0
 
 function _init()
     -- inialize things here
@@ -35,11 +36,16 @@ function _update()
         elseif (btnp(4)) then
             if selected_blob != 0 then
                 sfx(1)
-                log_msg = "locked in blob " .. selected_blob
-                state = "racing"
+                lock_timer = 0
+                state = "locked_in"
             else
                 log_msg = "please select a blob first"
             end
+        end
+    elseif (state == "locked_in") then
+        log_msg = "locked in blob " .. selected_blob
+        if (btnp(4)) then
+            state = "racing"
         end
     elseif (state == "racing") then
         if (btnp(4)) then
@@ -88,12 +94,18 @@ function _draw()
         end
 
         print("press 🅾️ to lock in", 20, 90, 6)
+    elseif (state == "locked_in") then
+        print("you've locked in on blob " .. selected_blob, 20, 20, 7)
+        print("press 🅾️ to race!", 20, 40, 6)
+        if (logging) then 
+            print(log_msg, 0, 120, 5)
+        end
     elseif (state == "racing") then
         print("the race is on!", 20, 20, 7)
         print("press 🅾️ to see result", 20, 40, 6)
     elseif (state == "result") then
         print("the race is over!!", 20, 20, 7)
-        print("press 🅾️ to play again", 20, 0, 6)
+        print("press 🅾️ to play again", 20, 40, 6)
     end
 end
 __gfx__


### PR DESCRIPTION
This pull request enhances the gameplay experience in `blob_race.p8` by introducing blob selection mechanics, visual effects, and logging for debugging. The most important changes include adding a blob selection system, visual enhancements for blob animations, and a logging mechanism for debugging purposes.

### Gameplay Enhancements:
* Added a blob selection system where players can choose between two blobs (`btnp(0)` for left blob and `btnp(1)` for right blob). Players can lock in their selection with `btnp(4)`, transitioning the game state to "locked_in".
* Introduced a new game state, "locked_in", where the selected blob is confirmed, and the player can proceed to the race.

### Visual Enhancements:
* Added animated effects for blob selection, including dynamic size changes (`blob_pulse` and `blob_pulse_2`) and a bobbing arrow to highlight the selected blob (`bobbing_offset` and `wiggle_offset`).
* Adjusted the layout of text and visual elements for better readability, such as repositioning the "play again" prompt in the "result" state.

### Debugging and Logging:
* Introduced a logging mechanism with a `logging` flag and `log_msg` variable to display debug messages on the screen during gameplay. Example messages include "left blob selected" and "please select a blob first". [[1]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR7-R15) [[2]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR64-R108)

### Audio Enhancements:
* Added sound effects (`__sfx__`) for blob selection and locking in, enhancing the auditory feedback during gameplay.