### PR TITLE
chore(linting): add picotool linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint Pico-8 Cart
+
+on:
+  push:
+    paths:
+      - '**.p8'
+  pull_request:
+    paths:
+      - '**.p8'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install picotool
+      run: |
+        pip install picotool
+
+    - name: Lint .p8 files
+      run: |
+        for file in $(find . -name "*.p8"); do
+          echo "Linting $file"
+          picotool lint "$file"
+        done


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to lint Pico-8 `.p8` files. The workflow ensures that all `.p8` files are checked for syntax or style issues during both push and pull request events.

### New GitHub Actions Workflow:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R1-R33): Added a workflow named "Lint Pico-8 Cart" that triggers on changes to `.p8` files. It checks out the repository, sets up Python, installs `picotool`, and runs a linting process on all `.p8` files. This is an attempt to add a github workflow that will lint the .p8 file on PRs.