### PR TITLE
fix(linting): call specific repo for picotool

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install picotool
+    - name: Install picotool from GitHub
       run: |
-        pip install picotool
+        pip install git+https://github.com/dansanderson/picotool.git
 
     - name: Lint .p8 files
       run: |


### PR DESCRIPTION
Picotool wasn't getting picked up in the github action. This fix specifically calls out the repo it is in to load it into the action.