### PR TITLE
fix(linting): change path to github_path

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install picotool from GitHub
       run: |
         pip install --user git+https://github.com/dansanderson/picotool.git
-        export PATH="$HOME/.local/bin:$PATH"
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Verify picotool installation
       run: |


### PR DESCRIPTION
This fix changes $PATH to $GITHUB_PATH to ensures that the $PATH update persists across different steps in the workflow.