### PR TITLE
fix(linting): explicitly add $HOME to path

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,10 +25,11 @@ jobs:
       run: |
         pip install --user git+https://github.com/dansanderson/picotool.git
         echo "$HOME/.local/bin" >> $GITHUB_PATH
+        export PATH="$HOME/.local/bin:$PATH"  # Ensure the path is updated for this step
 
     - name: Verify picotool installation
       run: |
-        which picotool || echo "picotool not found"
+        which picotool || exit 1  # Fail if picotool is still not found
 
     - name: Lint .p8 files
       run: |


### PR DESCRIPTION
Explicitly add $HOME/.local/bin to the PATH for the current step using export PATH="$HOME/.local/bin:$PATH".