### PR TITLE
fix(logging): correct overheat logging

### DIFF
--- a/blob_race.p8
+++ b/blob_race.p8
@@ -105,11 +105,11 @@ function _update()
                 overheat_timer = 0
                 boost_amount = 0.01
                 log_msg = "overheat off!"
+            else
+                player_boost_active = false
+                boost_amount = -0.5
+                log_msg = "overheating! no boost!"
             end
-
-            player_boost_active = false
-            boost_amount = -0.5
-            log_msg = "overheating! no boost!"
         else
             log_msg = "racing..."
         end


### PR DESCRIPTION
This pull request includes a small change to the `blob_race.p8` file, specifically within the `_update()` function. The change fixes the placement of an `else` block to ensure proper logic flow when handling the overheat and boost states.I had the order of ops wrong for a second part of the overheat conditional so logging wouldn't work. This fixes that.