### PR TITLE
refactor(boost): cleanup boost setup

### DIFF
--- a/blob_race.p8
+++ b/blob_race.p8
@@ -70,6 +70,8 @@ function _update()
         lock_timer += 1
         if (lock_timer > 119) then
             state = "racing"
+
+            -- blob setup
             blob1_x = 20
             blob2_x = 20
             blob1_y = 50
@@ -77,16 +79,17 @@ function _update()
             blob1_speed = (0.5 * rnd(1)) + 0.08
             blob2_speed = (0.5 * rnd(1)) + 0.08
 
+            -- boost setup
+            player_boost_meter = 100
+            player_boost_active = false
+            player_overheat = false
+
             -- testing values
             -- blob1_speed = 0.3
             -- blob2_speed = 0.3
 
             race_winner = 0
         end
-
-        player_boost_meter = 100
-        player_boost_active = false
-        player_overheat = false
 
         if (selected_blob == 1) then
             player_blob_speed = blob1_speed


### PR DESCRIPTION
This pull request refactors the initialization of player boost variables in the `function _update()` within `blob_race.p8`. The changes improve code organization by moving the boost setup into the block where the race state is initialized.

Key changes:

### Code organization improvements:
* Moved the initialization of `player_boost_meter`, `player_boost_active`, and `player_overheat` into the `"racing"` state setup block to group related logic for better readability and maintainability. These variables were previously initialized outside of this block.The boost set up was being called every frame of the countdown state. This commit moves the setup to be called right before the state is moved to racing.