### PR TITLE
fix(opponent-boost): add boost reset

### DIFF
--- a/blob_race.p8
+++ b/blob_race.p8
@@ -101,6 +101,7 @@ function _update()
              opponent_overheat = false
              opponent_overheat_timer = 0
              opponent_boost_amount = 0
+             opponent.overheat = false
 
             -- testing values
             -- blob1_speed = 0.3


### PR DESCRIPTION
This commit fixes the bug referenced in #33. It makes it so that the opponent will use its boost in a replay.

Closes #33