### PR TITLE
Feature/add blob sprites

### DIFF
--- a/blob_race.p8
+++ b/blob_race.p8
@@ -61,11 +61,11 @@ function _update()
         if (btnp(0)) then -- left blob (1)
             selected_blob = 1
             sfx(0)
-            log_msg = "left blob selected"
+            log_msg = "blob 1 selected"
         elseif (btnp(1)) then -- right blob (2)
             selected_blob = 2
             sfx(0)
-            log_msg = "right blob selected"
+            log_msg = "blob 2 selected"
         elseif (btnp(4)) then
             if selected_blob != 0 then
                 sfx(1)
@@ -188,6 +188,7 @@ function _update()
         if (btnp(4)) then
             state = "start"
         end
+        log_msg = "result state"
     end
 end
 
@@ -217,9 +218,6 @@ function _draw()
         print("choose your blob!", 20, 20, 7)
 
         -- draw blobs
-        -- circfill(30, 60, 8 + blob_pulse, 11) -- left blob (color 11 = light blue)
-        -- circfill(90, 60, 8 + blob_pulse_2, 8) -- right blob (color 8 = red)
-
         sspr(blob1_sprite_frame * 8, 0, 8, 8, 30-12, 60-12 + blob_pulse, 24, 24, blob1_flip, false)
         sspr(blob2_sprite_frame * 8, 0, 8, 8, 90-12, 60-12 + blob_pulse_2, 24, 24, blob2_flip, false)
 


### PR DESCRIPTION
This pull request enhances the `blob_race.p8` game by introducing animated blob sprites, updating the visual and textual elements for clarity, and improving the graphical assets. The changes focus on improving the user experience and visual appeal of the game.

### Sprite Animation and Graphics Updates:
* Introduced animated blob sprites with frame-based animations and flipping logic for both blobs. (`[[1]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR206-R211)`, `[[2]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cL210-R249)`, `[[3]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cL258-R283)`)
* Updated the sprite sheet (`__gfx__`) to include new frames for the animated blobs. (`[blob_race.p8L353-R375](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cL353-R375)`)

### Visual and Textual Improvements:
* Replaced static circular blob visuals with sprite-based rendering in the selection, locked-in, and racing states. (`[[1]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cL210-R249)`, `[[2]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cL258-R283)`)
* Adjusted text labels and positions for better alignment and readability, such as moving the blob numbers and selection indicators. (`[blob_race.p8L210-R249](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cL210-R249)`)

### Logging Enhancements:
* Updated log messages to use consistent terminology ("blob 1" and "blob 2" instead of "left blob" and "right blob"). (`[blob_race.p8L60-R68](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cL60-R68)`)
* Added a log message for the "result" state to improve state tracking during gameplay. (`[blob_race.p8R191](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR191)`)

Closes Issue: #39 
Closes Issue: #40 
Closes Issue: #41 