### PR TITLE
Feature/boost balance

### DIFF
--- a/blob_race.p8
+++ b/blob_race.p8
@@ -55,9 +55,7 @@ function _init()
 
     boost_meter = {
         fastest_blob = nil,
-        bonus = nil,
-        player = nil,
-        opponent = nil
+        bonus = nil
     }
 
     -- player boost table
@@ -149,14 +147,12 @@ function _update()
             boost_balance(blob1_speed, blob2_speed)
 
             -- player boost setup
-            player_boost.meter = boost_meter.player
             player_boost.active = false
             player_boost.overheating = false
             player_boost.overheating_timer = 0
             player_boost.amount = 0
 
             -- opponent boost setup
-            opponent_boost.meter = boost_meter.opponent
             opponent_boost.active = false
             opponent_boost.overheating = false
             opponent_boost.overheating_timer = 0
@@ -381,22 +377,21 @@ end
 
 function boost_balance(blob1_speed, blob2_speed)
     local boost_base = 100
-
     if (selected_blob == 1) then
         if (boost_meter.fastest_blob == 1) then
-            boost_meter.player = boost_base
-            boost_meter.opponent = boost_base + boost_meter.bonus
+            player_boost.meter = boost_base
+            opponent_boost.meter = boost_base + boost_meter.bonus
         else
-            boost_meter.player = boost_base + boost_meter.bonus
-            boost_meter.opponent = boost_base
+            player_boost.meter = boost_base + boost_meter.bonus
+            opponent_boost.meter = boost_base
         end
     elseif (selected_blob == 2) then
         if (boost_meter.fastest_blob == 2) then
-            boost_meter.player = boost_base
-            boost_meter.opponent = boost_base + boost_meter.bonus
+            player_boost.meter = boost_base
+            opponent_boost.meter = boost_base + boost_meter.bonus
         else
-            boost_meter.player = boost_base + boost_meter.bonus
-            boost_meter.opponent = boost_base
+            player_boost.meter = boost_base + boost_meter.bonus
+            opponent_boost.meter = boost_base
         end
     end
 end


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to the `blob_race.p8` game logic, focusing on improving gameplay dynamics by introducing a boost meter system, balancing mechanics, and cleaning up the code. Below is a summary of the most important changes:

### Gameplay Enhancements:
* Added a new `boost_meter` system to track the fastest blob and calculate a boost bonus based on the speed difference between blobs. (`[[1]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR56-R60)`, `[[2]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR354-R398)`)
* Introduced the `boost_balance` function to dynamically balance the boost meters for the player and opponent based on the fastest blob and the calculated bonus. (`[blob_race.p8R354-R398](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR354-R398)`)

### State and Logic Updates:
* Added a `lock_timer` variable to the "game-start" state to manage countdown timing and ensure a smooth transition to the "racing" state. (`[[1]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR87)`, `[[2]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR138-L147)`)
* Moved the `state = "racing"` assignment to the appropriate location in the countdown logic to ensure proper game flow. (`[blob_race.p8R165-R169](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR165-R169)`)

### Code Cleanup:
* Removed the initialization of `lock_timer` from `game_score_init()` and replaced it with a `game_over` flag for better clarity and separation of concerns. (`[blob_race.p8L331-R343](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cL331-R343)`)
* Commented out the `log_msg` for the countdown timer and added a new log message to display the boost meter values during the "racing" state for debugging purposes. (`[[1]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR165-R169)`, `[[2]](diffhunk://#diff-32dc314fe3d340c948a690d34668767b8c7b599c7f165fc65e5f065e945d3e9cR180-R181)`)

Closes #61 