### PR TITLE
bug(opponent-score): add fix

### DIFF
--- a/blob_race.p8
+++ b/blob_race.p8
@@ -627,13 +627,14 @@ end
 function update_scoring()
     -- Determine the player's chosen blob's moneyline
     local player_moneyline
-    local abs_moneyline = abs(player_moneyline)
 
     if (selected_blob == 1) then
         player_moneyline = win_probability.blob1_moneyline
     else
         player_moneyline = win_probability.blob2_moneyline
     end
+
+    local abs_moneyline = abs(player_moneyline)
 
     if (race_winner == selected_blob) then
         -- Player wins


### PR DESCRIPTION
This pull request includes a minor change to the `update_scoring` function in the `blob_race.p8` file. The change moves the initialization of the `abs_moneyline` variable to occur after the `player_moneyline` is assigned a value, ensuring it is calculated correctly.

We were setting the abs_moneyline before the player_moneyline was set and so it was being set to nil and silently failing on us in the update_scoring() function. This commit fixes this bug.

Closes #71 