### PR TITLE
bugfix(jekyll): fix template rendering

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -56,7 +56,8 @@
           {% for post in site.posts %}
             <li>
               <a href="{{ post.url }}">{{ post.title }}</a>
-              <p>{{ post.excerpt }}</p>
+              <p>{{ post.date | date: "%B %d, %Y" }}</p>
+              <div>{{ post.excerpt }}</div>
             </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
I wasn't using the appropriate template syntax to render the blog posts from the index file. This should correct that.